### PR TITLE
traffic_sanity_checks

### DIFF
--- a/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
@@ -19,7 +19,8 @@ class DailyTrafficPage extends StatelessWidget {
     var transportMode = context.watch<DailyTrafficProvider>().mode;
 
     return Scaffold(
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset:
+          false, // to prevent overflow when keyboard is showing
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
         title: const Text('Traffic Information'),

--- a/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
@@ -412,14 +412,13 @@ Future<void> showSavedDestinations(BuildContext context) async {
             // ignore: sized_box_for_whitespace
             content: Container(
               width: double.maxFinite,
-              height: 300,
+              height: 200,
               child: ListView.builder(
                 itemCount: savedDestinations.length,
                 itemBuilder: (BuildContext context, int index) {
                   return Column(
                     children: <Widget>[
                       SavedDestinationItem(savedDestinations[index]),
-                      if (index < savedDestinations.length - 1) const Divider(),
                     ],
                   );
                 },

--- a/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
@@ -525,7 +525,7 @@ Future<void> addDestinationDialog(BuildContext context) async {
                 String newAddress = addressController.text;
 
                 if (isValidInput(newName) && isValidInput(newAddress)) {
-                  // both strings not empty or over 50 characters
+                  // both strings not empty or over 50 characters, without special characters
                   // the name does not already exist
                   if (!destinationNames.contains(newName.toLowerCase())) {
                     if (await isValidLocation(newAddress)) {

--- a/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
@@ -19,6 +19,7 @@ class DailyTrafficPage extends StatelessWidget {
     var transportMode = context.watch<DailyTrafficProvider>().mode;
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
         title: const Text('Traffic Information'),

--- a/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic.ui.dart
@@ -452,6 +452,33 @@ Future<void> showSavedDestinations(BuildContext context) async {
   );
 }
 
+void nameAlreadyExistsDialog(BuildContext context) {
+  showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Oops!'),
+          content: const SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('There is already a saved destination with this name!'),
+                Text('Try another name for this address.'),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      });
+}
+
 Future<void> addDestinationDialog(BuildContext context) async {
   TextEditingController nameController = TextEditingController(text: '');
   TextEditingController addressController = TextEditingController(text: '');
@@ -492,47 +519,34 @@ Future<void> addDestinationDialog(BuildContext context) async {
             },
           ),
           TextButton(
-            child: const Text('Save'),
-            onPressed: () async {
-              String newName = nameController.text;
-              String newAddress = addressController.text;
+              child: const Text('Save'),
+              onPressed: () async {
+                String newName = nameController.text;
+                String newAddress = addressController.text;
 
-              if (!destinationNames.contains(newName.toLowerCase())) {
-                // the name does not already exist
-                Provider.of<DailyTrafficProvider>(context, listen: false)
-                    .addNewDestination(newName, newAddress);
-                Navigator.of(context).pop();
-              } else {
-                // the name already exists in saved destinations
-                showDialog(
-                  context: context,
-                  builder: (context) {
-                    return AlertDialog(
-                      title: const Text('Oops!'),
-                      content: const SingleChildScrollView(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                                'There is already a saved destination with this name!'),
-                            Text('Try another name for this address.'),
-                          ],
-                        ),
-                      ),
-                      actions: <Widget>[
-                        TextButton(
-                          child: const Text('OK'),
-                          onPressed: () {
-                            Navigator.of(context).pop();
-                          },
-                        ),
-                      ],
-                    );
-                  },
-                );
-              }
-            },
-          ),
+                if (isValidInput(newName) && isValidInput(newAddress)) {
+                  // both strings not empty or over 50 characters
+                  // the name does not already exist
+                  if (!destinationNames.contains(newName.toLowerCase())) {
+                    if (await isValidLocation(newAddress)) {
+                      // valid location
+                      // adds the new destination
+                      Provider.of<DailyTrafficProvider>(context, listen: false)
+                          .addNewDestination(newName, newAddress);
+                      Navigator.of(context).pop();
+                    } else {
+                      // alerts the user that the given address is not a valid location
+                      addressNotValidDialog(context);
+                    }
+                  } else {
+                    // the name already exists in saved destinations
+                    nameAlreadyExistsDialog(context); // alerts the user
+                  }
+                } else {
+                  // the inputs are not valid or they are empty strings
+                  inputNotValidDialog(context);
+                }
+              }),
         ],
       );
     },

--- a/good_morning/lib/ui/daily_traffic/daily_traffic_destinations.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic_destinations.dart
@@ -22,7 +22,7 @@ void inputNotValidDialog(BuildContext context) {
       return AlertDialog(
           title: const Text('Invalid input'),
           content: const Text(
-              'The address input cannot be empty and/or longer than 50 characters. Please try again.'),
+              'The address input cannot be empty and/or longer than 50 characters. The input cannot contain special characters such as !@#\$%^&*(),.?":{}|<>.  Please try again.'),
           actions: [
             TextButton(
               child: const Text('OK'),

--- a/good_morning/lib/ui/daily_traffic/daily_traffic_destinations.dart
+++ b/good_morning/lib/ui/daily_traffic/daily_traffic_destinations.dart
@@ -22,7 +22,7 @@ void inputNotValidDialog(BuildContext context) {
       return AlertDialog(
           title: const Text('Invalid input'),
           content: const Text(
-              'The address input cannot be empty and/or longer than 50 characters. The input cannot contain special characters such as !@#\$%^&*(),.?":{}|<>.  Please try again.'),
+              'The address input cannot be empty and/or longer than 50 characters. The input cannot contain special characters such as !@#\$%^&*().?":{}|<>.  Please try again.'),
           actions: [
             TextButton(
               child: const Text('OK'),
@@ -123,11 +123,17 @@ class DestinationItem extends StatelessWidget {
                 ),
                 actions: [
                   TextButton(
+                    child: const Text('Edit saved destinations'),
+                    onPressed: () {
+                      showSavedDestinations(context);
+                    },
+                  ),
+                  TextButton(
                     child: const Text('Cancel'),
                     onPressed: () {
                       Navigator.pop(context);
                     },
-                  )
+                  ),
                 ]);
           });
     }

--- a/good_morning/lib/utils/daily_fact_provider.dart
+++ b/good_morning/lib/utils/daily_fact_provider.dart
@@ -27,7 +27,7 @@ class DailyFactProvider extends ChangeNotifier {
         Duration(minutes: 5); // checks every 5 minutes
     Timer.periodic(checkInterval, (timer) {
       DateTime now = DateTime.now();
-      //if (now.isAfter(lastFetchedDate.add(Duration(minutes: 2)))) {
+      //
       if (isDifferentDay(lastFetchedDate, now)) {
         // checks against provider`s variable lastFetchedDate from the last fetch
         // New day has started, fetch a new factText
@@ -75,7 +75,6 @@ class DailyFactProvider extends ChangeNotifier {
     DateTime currentDate = DateTime.now();
 
     if (isDifferentDay(storedDate, currentDate)) {
-      //if (storedDate.isBefore(currentDate.subtract(Duration(minutes: 2)))) {
       // last text fetched more than one day ago
       try {
         String factData = await fetchDailyFact(); // fetches new fact

--- a/good_morning/lib/utils/daily_traffic/daily_traffic_api.dart
+++ b/good_morning/lib/utils/daily_traffic/daily_traffic_api.dart
@@ -133,11 +133,6 @@ Future<Uint8List> getMapFromAPI(
   }
   String markers =
       'markers=color:red|label:A|$fromAddress&markers=color:blue|label:B|$toAddress';
-  String request =
-      '$directionsUrl?mode=$mode&destination=$toAddress&origin=$fromAddress&key=$mapApiKey';
-  if (kDebugMode) {
-    print('Sends request to API: $request');
-  }
 
   // gets the direction data from API, decodes and encodes
   http.Response directionsResponse = await http.get(Uri.parse(

--- a/good_morning/lib/utils/daily_traffic/daily_traffic_api.dart
+++ b/good_morning/lib/utils/daily_traffic/daily_traffic_api.dart
@@ -167,7 +167,7 @@ Future<Uint8List> getMapFromAPI(
       throw Exception('Failed to load map');
     }
   } else {
-    throw Exception('Failed to fetch directions');
+    throw Exception('Failed to fetch directions polyline');
   }
 }
 

--- a/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
+++ b/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
@@ -285,14 +285,22 @@ class DailyTrafficProvider extends ChangeNotifier {
   }
 }
 
+// checks whether the input is not empty, too long or contains special characters
 bool isValidInput(String address) {
-  return address.isNotEmpty && address.length <= 50;
+  RegExp specialCharRegex = RegExp(
+      r'[!@#\$%^&*(),.?":{}|<>]'); // Define your set of special characters
+
+  return (address.isNotEmpty &&
+      address.length <= 50 &&
+      !specialCharRegex.hasMatch(address));
 }
 
+// checks if the address is a valid location (Google Address Validation API)
 Future<bool> isValidLocation(String address) async {
   return await isAddressValidLocation(address);
 }
 
+// Retrieves the user`s location
 Future<Map<String, String>> determinePosition() async {
   Map<String, String> positionMap = {
     'latitude': 'N/A',

--- a/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
+++ b/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
@@ -36,12 +36,6 @@ class DailyTrafficProvider extends ChangeNotifier {
 
   TransportMode get mode => _selectedMode;
 
-  // Variables for user`s position
-  String _myLatitude = '';
-  String _myLongitude = '';
-  String get myLatitude => _myLatitude;
-  String get myLongitude => _myLongitude;
-
   // For the transportation mode buttons
   bool _carIsSelected = true; // default transportation mode
   bool get carIsSelected => _carIsSelected;
@@ -179,8 +173,6 @@ class DailyTrafficProvider extends ChangeNotifier {
     String latitude = positionMap['latitude']!;
     String longitude = positionMap['longitude']!;
 
-    _myLatitude = latitude;
-    _myLongitude = longitude;
     // transforms into readable address
     String? address = await getAddressFromLatLng(latitude, longitude);
     if (address != null) {
@@ -288,7 +280,7 @@ class DailyTrafficProvider extends ChangeNotifier {
 // checks whether the input is not empty, too long or contains special characters
 bool isValidInput(String address) {
   RegExp specialCharRegex = RegExp(
-      r'[!@#\$%^&*(),.?":{}|<>]'); // Define your set of special characters
+      r'[!@#\$%^&*().?":{}|<>]'); // Define your set of special characters
 
   return (address.isNotEmpty &&
       address.length <= 50 &&

--- a/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
+++ b/good_morning/lib/utils/daily_traffic/daily_traffic_provider.dart
@@ -285,6 +285,14 @@ class DailyTrafficProvider extends ChangeNotifier {
   }
 }
 
+bool isValidInput(String address) {
+  return address.isNotEmpty && address.length <= 50;
+}
+
+Future<bool> isValidLocation(String address) async {
+  return await isAddressValidLocation(address);
+}
+
 Future<Map<String, String>> determinePosition() async {
   Map<String, String> positionMap = {
     'latitude': 'N/A',


### PR DESCRIPTION
Lade till sanity checks for alla input till destinations i trafikkortet, inga tomma strängar tillåts och inte längre strängar än 50 tecken. Kollar även adressfältet om det är en giltig (svensk) adress med hjälp av Google Address Validation API. 

Inmatningen av adressen funkar även om man skriver endast 'Parallellvägen 13E' och skippar postnumret och orten. Små stavfel är oftast ok om man skriver ut hela adressen med postnummer/ort, inte annars. Ganska känslig för stavfel, vissa input med stavfel accepteras av adressvalideringen och skickas vidare till nästa API men API som returnerar karta och ruttinfo förstår inte adressen sedan och jsonResponse returneras OK men listan i responsen som heter "routes" är tom och ger error. Polyline och ruttinfon etc kommer därifrån. Lagt till felhantering ifall routes är tom, visar text på skärmen istället för fula röda errors med overflow!

Lagt till actionknapp "Edit saved destinations" även från dialogfönstren för de orange destinationsknapparna där man sätter current destinations, så att man kan spara nya destinations därifrån utan att behöva gå via "your route" och default settings. Kändes inte så tydligt var man kunde lägga till nya.